### PR TITLE
A bunch of new build targets and configuration scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,5 @@ bootstrap:
 	$(MAKE) -C lib/generated bootstrap
 
 include $(TOP)/build/build.mk
-
+include $(TOP)/build/buildlibs.mk
+include $(TOP)/build/install.mk

--- a/build/buildlibs.mk
+++ b/build/buildlibs.mk
@@ -1,0 +1,46 @@
+-include $(TOP)/env.mk
+include $(TOP)/lib/files.mk
+
+CONFIG?=Release
+
+PCRE= \
+	pcre-osx \
+	pcre-iosdev \
+	pcre-iossim
+
+ALL_TARGETS= \
+	$(PCRE:%=$(TOP)/external-deps/%/.libs/libpcre16.a) \
+	$(TOP)/node-llvm/build/$(CONFIG)/llvm.node \
+	$(ALL_LIBRARIES:%=$(TOP)/runtime/%) \
+	$(COFFEE_SOURCES:%.coffee=$(TOP)/lib/generated/%.js) \
+	$(JS_SOURCES:%=$(TOP)/lib/generated/%) \
+	$(TOP)/ejs-llvm/libejsllvm-module.a \
+	$(TOP)/lib/generated/ejs.js.exe
+
+define pcrelib
+$(TOP)/external-deps/$(1)/.libs/libpcre16.a:
+	$(MAKE) -C external-deps build-$(1)
+endef
+$(foreach dir,$(PCRE),$(eval $(call pcrelib,$(dir))))
+
+define jslib
+$(TOP)/lib/generated/$(1).js: $(TOP)/lib/$(2)
+	make -C lib
+endef
+$(foreach file,$(COFFEE_SOURCES),$(eval $(call jslib,$(basename $(file)),$(file))))
+$(foreach file,$(JS_SOURCES),$(eval $(call jslib,$(basename $(file)),$(file))))
+
+$(TOP)/node-llvm/build/$(CONFIG)/llvm.node:
+	make -C node-llvm
+
+$(TOP)/ejs-llvm/libejsllvm-module.a:
+	make -C ejs-llvm
+
+$(TOP)/lib/generated/ejs.js.exe: $(TOP)/ejs $(TOP)/ejs-llvm/libejsllvm-module.a $(TOP)/node-llvm/build/$(CONFIG)/llvm.node
+	$(MAKE) -C lib/generated
+
+$(ALL_LIBRARIES:%=$(TOP)/runtime/%):
+	$(MAKE) -C runtime
+
+.PHONY: libs
+libs: $(ALL_TARGETS)

--- a/build/config.mk
+++ b/build/config.mk
@@ -1,3 +1,5 @@
+-include $(TOP)/env.mk
+
 PRODUCT_NAME=EchoJS
 PRODUCT_VERSION=0.1
 
@@ -24,10 +26,11 @@ DIST_ROOT=$(PRODUCT_INSTALL_ROOT)
 MKDIR=mkdir -p
 INSTALL=install
 CP=cp
+LN=ln -sf
 
 CFLAGS=-g -O2 -Wall -I. -Wno-unused-function
 
-MIN_IOS_VERSION=7.0
+MIN_IOS_VERSION?=7.0
 
 DEVELOPER_ROOT?=/Applications/Xcode.app/Contents/Developer
 IOS_SDK_VERSION?=7.0

--- a/build/ejs.in
+++ b/build/ejs.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+NODE_PATH=@libpath@/js @libpath@/ejs $@

--- a/build/install.mk
+++ b/build/install.mk
@@ -1,0 +1,67 @@
+-include $(TOP)/env.mk
+include $(TOP)/lib/files.mk
+
+CONFIG?=Release
+
+ESPRIMA= \
+	esprima.js
+
+ESCODEGEN= \
+	escodegen.js
+
+ESTRAVERSE= \
+	estraverse.js
+
+PCRE= \
+	pcre-osx \
+	pcre-iosdev \
+	pcre-iossim
+
+LIBDIRS= \
+	$(PCRE:%=external-deps/%/.libs) \
+	js \
+	runtime
+
+GENERATED = \
+	$(COFFEE_SOURCES:%.coffee=%.js) \
+	$(JS_SOURCES)
+
+LIBDIR=$(INSTALLDIR)/lib
+BINDIR=$(INSTALLDIR)/bin
+
+VPATH = $(TOP)/esprima:$(TOP)/estraverse:$(TOP)/escodegen:$(TOP)/lib/generated:$(TOP)/lib:$(TOP)/ejs-llvm:$(TOP)/runtime
+
+$(LIBDIRS:%=$(LIBDIR)/%) $(BINDIR) $(LIBDIR):
+	@$(MKDIR) $@
+
+$(LIBDIR)/js/%.js: %.js | $(LIBDIR)/js
+	@echo [Link] $(lastword $(subst /, ,$@)) && $(LN) $< $@
+
+$(LIBDIR)/js/llvm.node: $(TOP)/node-llvm/build/$(CONFIG)/llvm.node | $(LIBDIR)/js
+	@echo [Link] $(lastword $(subst /, ,$@)) && $(LN) $< $@
+
+define runtimelib
+$(LIBDIR)/runtime/$(1): $(1) | $(LIBDIR)/runtime
+	@echo [Link] $(1) && $(LN) $$< $$@
+endef
+$(foreach file,$(ALL_LIBRARIES),$(eval $(call runtimelib,$(file))))
+
+define pcreinstall
+$(LIBDIR)/external-deps/$(1)/.libs/libpcre16.a: $(TOP)/external-deps/$(1)/.libs/libpcre16.a | $(LIBDIR)/external-deps/$(1)/.libs
+	@echo [Link] $(lastword $(subst /, ,$$@)) && $(LN) $$< $$@
+endef
+$(foreach dir,$(PCRE),$(eval $(call pcreinstall,$(dir))))
+
+$(LIBDIR)/ejs: $(TOP)/ejs | $(LIBDIR)
+	@echo [Link] $(lastword $(subst /, ,$@)) && $(LN) $< $@
+
+$(LIBDIR)/ejs.js.exe: ejs.js.exe | $(LIBDIR)
+	@echo [Link] $(lastword $(subst /, ,$@)) && $(LN) $< $@
+
+$(BINDIR)/ejs: $(TOP)/build/ejs.in | $(BINDIR)
+	@sed -e "s,@libpath@,$(LIBDIR),g" < $< > $@
+	@chmod +x $@
+
+install-all: $(PCRE:%=$(LIBDIR)/external-deps/%/.libs/libpcre16.a) $(BINDIR)/ejs $(LIBDIR)/ejs $(LIBDIR)/ejs.js.exe $(ESPRIMA:%=$(LIBDIR)/js/%) $(ESCODEGEN:%=$(LIBDIR)/js/%) $(ESTRAVERSE:%=$(LIBDIR)/js/%) $(GENERATED:%=$(LIBDIR)/js/%) $(LLVM:%=$(LIBDIR)/js/%) $(ALL_LIBRARIES:%=$(LIBDIR)/runtime/%)
+
+install: libs install-all

--- a/configure
+++ b/configure
@@ -1,0 +1,125 @@
+#!/bin/bash
+usage()
+{
+cat <<EOF
+Usage:
+  --prefix                  Installation prefix (default: $(pwd)/out)
+  --llvm                    llvm suffix (for LLVM_SUFFIX)
+  --minosx                  Minimum OSX Version (if not on Mavericks)
+  --minios                  Minimum IOS Version (default 7.0)
+  --iossdk                  IOS SDK Version (default 7.0)
+
+Example:
+
+To build on Mountain Lion with XCode 4.6 and an llvm installed from brew (see README):
+
+  ./configure --minosx=10.8 --minios=6.1 --iossdk=6.1 --llvm=-34
+
+EOF
+}
+
+CNF=env.mk
+SH=env.sh
+
+cnf_append()
+{
+    printf "%-30s := %s\n" "$1" "${@:2}" >> $CNF
+}
+
+sh_append()
+{
+    printf "export %s=%s\n" "$1" "${@:2}" >> $SH
+}
+
+p=$(pwd)
+LIBRARY=libecho.a
+ALL_LIBRARIES="$LIBRARY $LIBRARY.sim $LIBRARY.armv7 $LIBRARY.armv7s $LIBRARY.ios"
+
+INSTALLDIR=$p/out
+LLVM_SUFFIX=
+MIN_OSX_VERSION=
+MIN_IOS_VERSION=
+IOS_SDK_VERSION=
+CONFIG=Release
+
+
+for arg; do
+  case "$arg" in
+    --help | -h)
+        usage
+        exit 1
+      ;;
+    --prefix=* )
+      INSTALLDIR=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+    --llvm=* )
+      LLVM_SUFFIX=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+    --minosx=* )
+      MIN_OSX_VERSION=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+    --minios=* )
+      MIN_IOS_VERSION=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+    --iossdk=* )
+      IOS_SDK_VERSION=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+  esac
+done
+
+echo "Configuring..."
+
+cat >config.log <<EOF
+  $ $0 $@
+EOF
+
+rm -f $CNF
+rm -f $SH
+
+cnf_append "TOP" "$(pwd)"
+cnf_append "INSTALLDIR" "$INSTALLDIR"
+sh_append "INSTALLDIR" "$INSTALLDIR"
+cnf_append "OSX_LIBRARY" "$LIBRARY"
+cnf_append "SIM_LIBRARY" "$LIBRARY.sim"
+cnf_append "DEV_LIBRARY" "$LIBRARY.armv7"
+cnf_append "DEVS_LIBRARY" "$LIBRARY.armv7s"
+cnf_append "LIPOD_IOS_LIBRARY" "$LIBRARY.ios"
+cnf_append "ALL_LIBRARIES" "$ALL_LIBRARIES"
+
+if [ "x$LLVM_SUFFIX" != "x" ]; then
+    cnf_append "LLVM_SUFFIX" "$LLVM_SUFFIX"
+    sh_append "LLVM_SUFFIX" "$LLVM_SUFFIX"
+fi
+
+if [ "x$MIN_OSX_VERSION" != "x" ]; then
+    cnf_append "MIN_OSX_VERSION" "$MIN_OSX_VERSION"
+    sh_append "MIN_OSX_VERSION" "$MIN_OSX_VERSION"
+fi
+
+if [ "x$MIN_IOS_VERSION" != "x" ]; then
+    cnf_append "MIN_IOS_VERSION" "$MIN_IOS_VERSION"
+fi
+
+if [ "x$IOS_SDK_VERSION" != "x" ]; then
+    cnf_append "IOS_SDK_VERSION" "$IOS_SDK_VERSION"
+fi
+
+cnf_append "CONFIG" "$CONFIG"
+
+if [ ! -d $INSTALLDIR ]; then
+    mkdir $INSTALLDIR
+fi
+
+git submodule init
+git submodule update
+
+cat <<EOF
+
+Configuration done.
+You should now run:
+
+  ". ./env.sh" to load the environment settings (mind the dots)
+  "make libs" to build stuff
+  "make install" to install everything into $INSTALLDIR
+
+EOF

--- a/external-deps/Makefile
+++ b/external-deps/Makefile
@@ -1,4 +1,4 @@
-TOP=..
+TOP=$(shell pwd)/..
 
 LLVM_CXXFLAGS="`$LLVM_CONFIG --cxxflags` -fno-rtti"
 LLVM_LDFLAGS=`$LLVM_CONFIG --ldflags`
@@ -31,7 +31,7 @@ clean-pcre: $(PCRE_TARGETS:%=clean-pcre-%)
 configure-pcre-osx:
 	@mkdir -p pcre-osx
 	(cd pcre-osx && \
-	../$(TOP)/pcre/configure $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-osx
+	$(TOP)/pcre/configure $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-osx
 
 configure-pcre-iossim:
 	@mkdir -p pcre-iossim
@@ -41,7 +41,7 @@ configure-pcre-iossim:
 	CXX="clang++ $(IOSSIM_ARCH) $(IOSSIM_ARCH_FLAGS) -miphoneos-version-min=$(MIN_IOS_VERSION) -isysroot $(IOSSIM_SYSROOT)" \
 	LD="clang" \
 	AS="$(IOSSIM_ROOT)/usr/bin/as" \
-	../$(TOP)/pcre/configure --host=$(IOSSIM_TRIPLE) $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-iossim
+	$(TOP)/pcre/configure --host=$(IOSSIM_TRIPLE) $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-iossim
 
 configure-pcre-iosdev:
 	@mkdir -p pcre-iosdev
@@ -51,7 +51,7 @@ configure-pcre-iosdev:
 	CXX="clang++ $(IOSDEV_ARCH) $(IOSDEV_ARCH_FLAGS) -miphoneos-version-min=$(MIN_IOS_VERSION) -isysroot $(IOSDEV_SYSROOT)" \
 	LD="clang" \
 	AS="$(IOSDEV_ROOT)/usr/bin/as" \
-	../$(TOP)/pcre/configure --host=$(IOSDEV_TRIPLE) $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-iosdev
+	$(TOP)/pcre/configure --host=$(IOSDEV_TRIPLE) $(PCRE_CONFIGURE_ARGS)) || rm -rf pcre-iosdev
 
 build-pcre-osx: configure-pcre-osx
 	$(MAKE) -C pcre-osx pcre_chartables.c libpcre16.la
@@ -74,7 +74,7 @@ clean-pcre-osx:
 configure-llvm:
 	@mkdir -p llvm-osx
 	(cd llvm-osx && \
-	../$(TOP)/llvm/configure  $(LLVM_CONFIGURE_ARGS)) || rm -rf llvm-osx
+	$(TOP)/llvm/configure  $(LLVM_CONFIGURE_ARGS)) || rm -rf llvm-osx
 
 build-llvm: configure-llvm
 	$(MAKE) -C llvm-osx

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,23 +1,7 @@
 TOP=..
+CURRENT=$(TOP)/lib
 
-COFFEE_SOURCES=				\
-	nodevisitor.coffee		\
-	compiler.coffee			\
-	debug.coffee			\
-	echo-util.coffee		\
-	closure-conversion.coffee	\
-	optimizations.coffee		\
-	types.coffee			\
-	consts.coffee			\
-	exitable-scope.coffee		\
-	runtime.coffee			\
-	terminal.coffee			\
-	jscfa2.coffee
-
-JS_SOURCES=				\
-	map.js				\
-	set.js				\
-	stack.js
+include $(CURRENT)/files.mk
 
 DESTDIR = generated
 

--- a/lib/files.mk
+++ b/lib/files.mk
@@ -1,0 +1,18 @@
+COFFEE_SOURCES=				\
+	nodevisitor.coffee		\
+	compiler.coffee			\
+	debug.coffee			\
+	echo-util.coffee		\
+	closure-conversion.coffee	\
+	optimizations.coffee		\
+	types.coffee			\
+	consts.coffee			\
+	exitable-scope.coffee		\
+	runtime.coffee			\
+	terminal.coffee			\
+	jscfa2.coffee
+
+JS_SOURCES=				\
+	map.js				\
+	set.js				\
+	stack.js

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,8 +1,10 @@
 TOP=..
 
 include $(TOP)/build/build.mk
+-include $(TOP)/env.config
 
-LIBRARY=libecho.a
+LIBRARY?=libecho.a
+
 C_SOURCES= \
 	ejs-arguments.c \
 	ejs-array.c \
@@ -49,11 +51,11 @@ DEVS_OBJECTS=$(C_SOURCES:%.c=%.o.armv7s) $(OBJC_SOURCES:%.m=%.o.armv7s) main.o.a
 analyze_plists_c = $(C_SOURCES:%.c=%.plist) main.plist
 analyze_plists_objc = $(OBJC_SOURCES:%.m=%.plist) 
 
-OSX_LIBRARY=$(LIBRARY)
-SIM_LIBRARY=$(LIBRARY).sim
-DEV_LIBRARY=$(LIBRARY).armv7
-DEVS_LIBRARY=$(LIBRARY).armv7s
-LIPOD_IOS_LIBRARY=$(LIBRARY).ios
+OSX_LIBRARY?=$(LIBRARY)
+SIM_LIBRARY?=$(LIBRARY).sim
+DEV_LIBRARY?=$(LIBRARY).armv7
+DEVS_LIBRARY?=$(LIBRARY).armv7s
+LIPOD_IOS_LIBRARY?=$(LIBRARY).ios
 
 ifneq ($(TRAVIS_BUILD_NUMBER),)
 ALL_LIBRARIES=$(OSX_LIBRARY)


### PR DESCRIPTION
Configuration tool and new targets for setting everything up from scratch so I can play

new targets: libs, install
configuration: creates env.mk, which does the same as build/config-local.mk but auto-generated (I didn't touch the config-local logic, so both should work fine)

make libs tracks all the needed build artifacts and triggers make -C for each
make install creates a directory structure of everything that ejs and ejs.js.exe need (symlinks), and creates a launcher script for ejs with NODE_PATH set correctly
