### PR TITLE
Fixed function name capitalization changes for ejs-llvm.

### DIFF
--- a/ejs-llvm/allocainst.cpp
+++ b/ejs-llvm/allocainst.cpp
@@ -80,7 +80,7 @@ namespace ejsllvm {
     {
         _ejs_AllocaInst_specops = _ejs_Object_specops;
         _ejs_AllocaInst_specops.class_name = "LLVMAllocaInst";
-        _ejs_AllocaInst_specops.allocate = AllocaInst_allocate;
+        _ejs_AllocaInst_specops.Allocate = AllocaInst_allocate;
 
         _ejs_gc_add_root (&_ejs_AllocaInst_prototype);
         _ejs_AllocaInst_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_AllocaInst_specops);

--- a/ejs-llvm/arraytype.cpp
+++ b/ejs-llvm/arraytype.cpp
@@ -81,7 +81,7 @@ namespace ejsllvm {
     {
         _ejs_ArrayType_specops = _ejs_Object_specops;
         _ejs_ArrayType_specops.class_name = "LLVMArray";
-        _ejs_ArrayType_specops.allocate = ArrayType_allocate;
+        _ejs_ArrayType_specops.Allocate = ArrayType_allocate;
 
         _ejs_gc_add_root (&_ejs_ArrayType_prototype);
         _ejs_ArrayType_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_ArrayType_specops);

--- a/ejs-llvm/basicblock.cpp
+++ b/ejs-llvm/basicblock.cpp
@@ -42,7 +42,7 @@ namespace ejsllvm {
             _ejs_throw_nativeerror_utf8 (EJS_TYPE_ERROR, "'this' in BasicBlock[Symbol.create] is not a constructor");
         EJSObject* F_ = EJSVAL_TO_OBJECT(F);
         // 2. Let obj be the result of calling OrdinaryCreateFromConstructor(F, "%DatePrototype%", ([[DateData]]) ). 
-        ejsval proto = OP(F_,get)(F, _ejs_atom_prototype, F);
+        ejsval proto = OP(F_,Get)(F, _ejs_atom_prototype, F);
         if (EJSVAL_IS_UNDEFINED(proto))
             proto = _ejs_BasicBlock_prototype;
 
@@ -119,7 +119,7 @@ namespace ejsllvm {
     {
         _ejs_BasicBlock_specops = _ejs_Object_specops;
         _ejs_BasicBlock_specops.class_name = "LLVMBasicBlock";
-        _ejs_BasicBlock_specops.allocate = BasicBlock_allocate;
+        _ejs_BasicBlock_specops.Allocate = BasicBlock_allocate;
 
         _ejs_gc_add_root (&_ejs_BasicBlock_prototype);
         _ejs_BasicBlock_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_BasicBlock_specops);

--- a/ejs-llvm/callinvoke.cpp
+++ b/ejs-llvm/callinvoke.cpp
@@ -113,7 +113,7 @@ namespace ejsllvm {
     {
         _ejs_Call_specops = _ejs_Object_specops;
         _ejs_Call_specops.class_name = "LLVMCall";
-        _ejs_Call_specops.allocate = Call_allocate;
+        _ejs_Call_specops.Allocate = Call_allocate;
 
         _ejs_gc_add_root (&_ejs_Call_prototype);
         _ejs_Call_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_Call_specops);
@@ -234,7 +234,7 @@ namespace ejsllvm {
     {
         _ejs_Invoke_specops = _ejs_Object_specops;
         _ejs_Invoke_specops.class_name = "LLVMInvoke";
-        _ejs_Invoke_specops.allocate = Invoke_allocate;
+        _ejs_Invoke_specops.Allocate = Invoke_allocate;
 
         _ejs_gc_add_root (&_ejs_Invoke_prototype);
         _ejs_Invoke_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_Invoke_specops);

--- a/ejs-llvm/function.cpp
+++ b/ejs-llvm/function.cpp
@@ -43,7 +43,7 @@ namespace ejsllvm {
             _ejs_throw_nativeerror_utf8 (EJS_TYPE_ERROR, "'this' in Function[Symbol.create] is not a constructor");
         EJSObject* F_ = EJSVAL_TO_OBJECT(F);
         // 2. Let obj be the result of calling OrdinaryCreateFromConstructor(F, "%DatePrototype%", ([[DateData]]) ). 
-        ejsval proto = OP(F_,get)(F, _ejs_atom_prototype, F);
+        ejsval proto = OP(F_,Get)(F, _ejs_atom_prototype, F);
         if (EJSVAL_IS_UNDEFINED(proto))
             proto = _ejs_Function_prototype;
 
@@ -227,7 +227,7 @@ namespace ejsllvm {
     {
         _ejs_Function_specops = _ejs_Object_specops;
         _ejs_Function_specops.class_name = "LLVMFunction";
-        _ejs_Function_specops.allocate = Function_allocate;
+        _ejs_Function_specops.Allocate = Function_allocate;
 
         _ejs_gc_add_root (&_ejs_Function_prototype);
         _ejs_Function_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_Function_specops);

--- a/ejs-llvm/globalvariable.cpp
+++ b/ejs-llvm/globalvariable.cpp
@@ -45,7 +45,7 @@ namespace ejsllvm {
             _ejs_throw_nativeerror_utf8 (EJS_TYPE_ERROR, "'this' in GlobalVariable[Symbol.create] is not a constructor");
         EJSObject* F_ = EJSVAL_TO_OBJECT(F);
         // 2. Let obj be the result of calling OrdinaryCreateFromConstructor(F, "%DatePrototype%", ([[DateData]]) ). 
-        ejsval proto = OP(F_,get)(F, _ejs_atom_prototype, F);
+        ejsval proto = OP(F_,Get)(F, _ejs_atom_prototype, F);
         if (EJSVAL_IS_UNDEFINED(proto))
             proto = _ejs_GlobalVariable_prototype;
 

--- a/ejs-llvm/landingpad.cpp
+++ b/ejs-llvm/landingpad.cpp
@@ -99,7 +99,7 @@ namespace ejsllvm {
     {
         _ejs_LandingPad_specops = _ejs_Object_specops;
         _ejs_LandingPad_specops.class_name = "LLVMLandingPad";
-        _ejs_LandingPad_specops.allocate = LandingPad_allocate;
+        _ejs_LandingPad_specops.Allocate = LandingPad_allocate;
 
         _ejs_gc_add_root (&_ejs_LandingPad_prototype);
         _ejs_LandingPad_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_LandingPad_specops);

--- a/ejs-llvm/loadinst.cpp
+++ b/ejs-llvm/loadinst.cpp
@@ -80,7 +80,7 @@ namespace ejsllvm {
     {
         _ejs_LoadInst_specops = _ejs_Object_specops;
         _ejs_LoadInst_specops.class_name = "LLVMLoadInst";
-        _ejs_LoadInst_specops.allocate = LoadInst_Allocate;
+        _ejs_LoadInst_specops.Allocate = LoadInst_Allocate;
 
         _ejs_gc_add_root (&_ejs_LoadInst_prototype);
         _ejs_LoadInst_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_LoadInst_specops);

--- a/ejs-llvm/module.cpp
+++ b/ejs-llvm/module.cpp
@@ -44,7 +44,7 @@ namespace ejsllvm {
         Module* module = (Module*)obj;
         if (module->llvm_module)
             delete module->llvm_module;
-        _ejs_Object_specops.finalize(obj);
+        _ejs_Object_specops.Finalize(obj);
     }
 
     static ejsval
@@ -55,7 +55,7 @@ namespace ejsllvm {
             _ejs_throw_nativeerror_utf8 (EJS_TYPE_ERROR, "'this' in Module[Symbol.create] is not a constructor");
         EJSObject* F_ = EJSVAL_TO_OBJECT(F);
         // 2. Let obj be the result of calling OrdinaryCreateFromConstructor(F, "%DatePrototype%", ([[DateData]]) ). 
-        ejsval proto = OP(F_,get)(F, _ejs_atom_prototype, F);
+        ejsval proto = OP(F_,Get)(F, _ejs_atom_prototype, F);
         if (EJSVAL_IS_UNDEFINED(proto))
             proto = _ejs_Module_prototype;
 
@@ -303,8 +303,8 @@ namespace ejsllvm {
     {
         _ejs_Module_specops = _ejs_Object_specops;
         _ejs_Module_specops.class_name = "LLVMModule";
-        _ejs_Module_specops.allocate = Module_allocate;
-        _ejs_Module_specops.finalize = Module_finalize;
+        _ejs_Module_specops.Allocate = Module_allocate;
+        _ejs_Module_specops.Finalize = Module_finalize;
 
         _ejs_gc_add_root (&_ejs_Module_prototype);
         _ejs_Module_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_Module_specops);

--- a/ejs-llvm/switch.cpp
+++ b/ejs-llvm/switch.cpp
@@ -92,7 +92,7 @@ namespace ejsllvm {
     {
         _ejs_Switch_specops = _ejs_Object_specops;
         _ejs_Switch_specops.class_name = "LLVMSwitch";
-        _ejs_Switch_specops.allocate = Switch_allocate;
+        _ejs_Switch_specops.Allocate = Switch_allocate;
 
         _ejs_gc_add_root (&_ejs_Switch_prototype);
         _ejs_Switch_prototype = _ejs_object_new(_ejs_Object_prototype, &_ejs_Switch_specops);


### PR DESCRIPTION
Fixes for function name capitalization broken at d17c9256fc5898976a5d9030e51275dee851816b.
