### PR TITLE
Initial, rudimentary impl of encodeURIComponent()

### DIFF
--- a/runtime/ejs-init.c
+++ b/runtime/ejs-init.c
@@ -185,6 +185,7 @@ _ejs_init(int argc, char** argv)
     _ejs_date_init(_ejs_global);
     _ejs_json_init(_ejs_global);
     _ejs_math_init(_ejs_global);
+    _ejs_uri_init(_ejs_global);
 
     // ES6 bits
     _ejs_promise_init(_ejs_global);

--- a/runtime/ejs-string.c
+++ b/runtime/ejs-string.c
@@ -235,7 +235,7 @@ utf16_to_utf8_char (const jschar* utf16, char* utf8, int *utf16_adv)
     EJS_NOT_IMPLEMENTED();
 }
 
-static int
+int
 ucs2_to_utf8_char (jschar ucs2, char *utf8)
 {
     if (ucs2 < 0x80) {

--- a/runtime/ejs-string.h
+++ b/runtime/ejs-string.h
@@ -113,6 +113,7 @@ jschar _ejs_string_ucs2_at (EJSPrimString* primstr, uint32_t offset);
 
 uint32_t _ejs_string_hash (ejsval str);
 
+int ucs2_to_utf8_char (jschar ucs2, char *utf8);
 char* _ejs_string_to_utf8(EJSPrimString* primstr);
 
 void _ejs_string_init_literal (const char *name, ejsval *val, EJSPrimString* str, jschar* ucs2_data, int32_t length);

--- a/runtime/ejs-uri.c
+++ b/runtime/ejs-uri.c
@@ -4,7 +4,107 @@
 
 #include <stdlib.h>
 
+#include "ejs-error.h"
+#include "ejs-ops.h"
+#include "ejs-string.h"
 #include "ejs-uri.h"
+
+static ejsval
+Encode (ejsval string, ejsval unescaped)
+{
+    EJSPrimString *stringObj = EJSVAL_TO_STRING(string);
+    jschar *unescapedStr = EJSVAL_TO_FLAT_STRING(unescaped);
+
+    /* 1. Let strLen be the number of code units in string. */
+    int32_t strLen = stringObj->length;
+
+    /* 2. Let R be the empty String. */
+    ejsval R = _ejs_atom_empty;
+
+    /* 3. Let k be 0. */
+    int32_t k = 0;
+
+    /* 4. Repeat. */
+    for (;;) {
+        /* a. If k equals strLen, return R. */
+        if (k == strLen)
+            return R;
+
+        /* b. Let C be the code unit at index k within string. */
+        jschar C = _ejs_string_ucs2_at (stringObj, k);
+        jschar C_arr [2] = { C, 0 };
+
+        /* c. If C is in unescapedSet, then */
+        jschar *p = ucs2_strstr (unescapedStr, C_arr);
+        if (p) {
+            /* i. Let S be a String containing only the code unit C. */
+            ejsval S = _ejs_string_new_substring (string, k, 1);
+
+            /* ii. Let R be a new String value computed by concatenating the previous value of R and S. */
+            R = _ejs_string_concat (R, S);
+        }
+        /* d. Else C is not in unescapedSet, */
+        else {
+            /* i. If the code unit value of C is not less than 0xDC00 and not greater than 0xDFFF, throw a URIError exception. */
+            if (C >= 0xDC00 && C <= 0xDFFF)
+                _ejs_throw_nativeerror_utf8 (EJS_URI_ERROR, "URI malformed");
+
+            /* ii. If the code unit value of C is less than 0xD800 or greater than 0xDBFF, then Let V be the code unit value of C. */
+            jschar V;
+            if (C < 0xD800 || C > 0xDBFF)
+                V = C;
+            /* iii. Else, */
+            else {
+                /* 1. Increase k by 1. */
+                k++;
+
+                /* 2. If k equals strLen, throw a URIError exception. */
+                if (k == strLen)
+                    _ejs_throw_nativeerror_utf8 (EJS_URI_ERROR, "URI malformed");
+
+                /* 3. Let kChar be the code unit value of the code unit at index k within string. */
+                jschar kChar = _ejs_string_ucs2_at (stringObj, k);
+
+                /* 4. If kChar is less than 0xDC00 or greater than 0xDFFF, throw a URIError exception. */
+                if (kChar < 0xDC00 || kChar > 0xDFFF)
+                    _ejs_throw_nativeerror_utf8 (EJS_URI_ERROR, "URI malformed");
+
+                /* 5. Let V be (((the code unit value of C) – 0xD800) × 0x400 + (kChar – 0xDC00) + 0x10000). */
+                V = (C - 0xD800) * 0x400 + (kChar - 0xDC00) + 0x10000;
+            }
+
+            /* iv. Let Octets be the array of octets resulting by applying the UTF-8 transformation to V, and let L be the array size. */
+            char octets[4];
+            int32_t L = ucs2_to_utf8_char (V, octets);
+
+            /* v. Let j be 0. */
+            int32_t j = 0;
+
+            /* vi. Repeat, while j < L. */
+            while (j < L) {
+                /* 1.  Let jOctet be the value at index j within Octets. */
+                char jOctet = octets [j];
+
+                /* 2. Let S be a String containing three code units “%XY” where XY are two uppercase hexadecimal
+                 * digits encoding the value of jOctet. */
+                char buff[4];
+                sprintf(buff, "%%%X", jOctet);
+                ejsval S = _ejs_string_new_utf8 (buff);
+
+                /* 3. Let R be a new String value computed by concatenating the previous value of R and S. */
+                R = _ejs_string_concat (R, S);
+
+                /* 4. Increase j by 1. */
+                j++;
+            }
+        }
+
+        /* e. Increase k by 1. */
+        k++;
+    }
+}
+
+static ejsval _ejs_uriUnescaped;
 
 ejsval _ejs_decodeURI EJSVAL_ALIGNMENT;
 ejsval _ejs_decodeURIComponent EJSVAL_ALIGNMENT;
@@ -33,5 +133,29 @@ _ejs_encodeURI_impl (ejsval env, ejsval _this, uint32_t argc, ejsval* args)
 ejsval
 _ejs_encodeURIComponent_impl (ejsval env, ejsval _this, uint32_t argc, ejsval* args)
 {
-    EJS_NOT_IMPLEMENTED();
+    ejsval uriComponent = _ejs_undefined;
+
+    if (argc >= 1)
+        uriComponent = args [0];
+
+    /* 1. Let componentString be ToString(uriComponent). */
+    /* 2. ReturnIfAbrupt(componentString). */
+    ejsval componentString = ToString(uriComponent);
+
+    /* 3. Let unescapedURIComponentSet be a String containing one instance of each code unit valid in uriUnescaped. */
+    ejsval unescapedURIComponentSet = _ejs_uriUnescaped;
+
+    /* 4. Return Encode(componentString, unescapedURIComponentSet) */
+    return Encode (componentString, unescapedURIComponentSet);
 }
+
+void
+_ejs_uri_init (ejsval global)
+{
+    /* 18.2.6.1 URI Syntax and Semantics */
+    /* a 'funny' thing is that we are flatting the string whenever we are encoding it. It would be nice to have it
+     * in that state always! */
+    char *uriUnescaped = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()";
+    _ejs_uriUnescaped = _ejs_string_new_utf8 (uriUnescaped);
+}
+

--- a/runtime/ejs-uri.h
+++ b/runtime/ejs-uri.h
@@ -21,6 +21,8 @@ ejsval _ejs_decodeURIComponent_impl (ejsval env, ejsval _this, uint32_t argc, ej
 ejsval _ejs_encodeURI_impl (ejsval env, ejsval _this, uint32_t argc, ejsval* args);
 ejsval _ejs_encodeURIComponent_impl (ejsval env, ejsval _this, uint32_t argc, ejsval* args);
 
+void _ejs_uri_init (ejsval global);
+
 EJS_END_DECLS
 
 #endif


### PR DESCRIPTION
This is some work I did not intend to do before the release, BUT given I needed it for my octo sample, I wanted to take a look and implement it. That being said, this is a rudimentary, non optimized version. Here's the list of things to observe:

1. It is a correct implementation, following the actual spec for encodeURIComponent() and its abstract Encoding() function.

2. We use _ejs_string_concat() extensively, as the spec requires to iterate over each character in the string passes as parameter, and we may end up with many ropes there. Something to think about later.

3. Created an internal global _ejs_uriUnescaped string, which is abstractly defined in the spec - we are still missing other members there, and I didn't put them since I don't use them myself (i.e. "uriReserved"). 

4. The Encode() function is expected to receive a pair of strings, and look for *every* input char in the _ejs_uriUnescaped - v8, on the other hand, simply takes the single value, and does some isAlpha() and char range checks on it, which is most likely faster/better, but no so spec-compliant. Something to consider ourselves?

4. Made ucs2_to_utf8_char() public, as it made my life easier implementing this function (see the actual code in case of doubt).
