### PR TITLE
Fix module references when using relative paths.

### DIFF
--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -2591,9 +2591,12 @@ class GatherImports extends TreeVisitor
                 throw new Error("import sources must be strings") if not is_string_literal(n.source)
 
                 source_path = n.source.value
+                is_imported_ref = false
                 
                 for v in @import_vars
-                        source_path = source_path.replace("$#{v.variable}", v.value);
+                        if source_path.indexOf("$#{v.variable}") >= 0
+                                is_imported_ref = true
+                                source_path = source_path.replace("$#{v.variable}", v.value)
 
                 if isNativeModule(n.source.value)
                         if @importList.indexOf(source_path) is -1
@@ -2604,7 +2607,11 @@ class GatherImports extends TreeVisitor
                         return n
                         
                 if source_path[0] isnt "/"
-                        source_path = path.resolve @toplevel_path, @path, source_path
+                        # Imported references (i.e. "$pirouette/foundation" are always relative to the toplevel dir)
+                        if is_imported_ref
+                                source_path = path.resolve @toplevel_path, source_path
+                        else
+                                source_path = path.resolve @toplevel_path, @path, source_path
 
                 if source_path.indexOf(process.cwd()) is 0
                         source_path = path.relative(process.cwd(), source_path)


### PR DESCRIPTION
Essentially, when using imported references, such as
"$pirouette/foundation", we want to have that flag
replaced with the passed value, *and* relative to the
working directory directly, no compiled file path
around.

An example would be compiling something like:
    ejs trackmix/trackmix.js -I pirouette=../pirouette/bindings/
    // import { NSObject } from '$pirouette/foundation';

When we are 'resolving' the foundation item, we would normally use the current directory, the file path, and the actual string literal there - in this case, the file path (trackmix/ directory) would be literally in our way, so dependency resolutions arise.
