### PR TITLE
Fix stage2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,8 @@ script:
   - EJS_STAGE=0 EJS_DRIVER="`pwd`/ejs" make -C test check
   - if test -f test/.failures -o -f test/.xsuccess; then exit -1; fi
   - make -C test clean
-  - EJS_STAGE=1 EJS_DRIVER="`pwd`/ejs.exe" make -C test check
+  - EJS_STAGE=1 EJS_DRIVER="`pwd`/ejs-es6.js.exe.stage1" make -C test check
+  - if test -f test/.failures -o -f test/.xsuccess; then exit -1; fi
+  - make -C test clean
+  - EJS_STAGE=2 EJS_DRIVER="`pwd`/ejs-es6.js.exe.stage2" make -C test check
   - if test -f test/.failures -o -f test/.xsuccess; then exit -1; fi

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all-local:: ensure-npmmodules ensure-submodules
 
 NODE_PATH?=$(shell $(MAKE) -C test node-path)
 
-all-hook:: stage1
+all-hook:: stage2
 
 install-local::
 	@$(MKDIR) $(bindir)

--- a/build/config.mk
+++ b/build/config.mk
@@ -33,7 +33,7 @@ MKDIR=mkdir -p
 INSTALL=install
 CP=cp
 
-CFLAGS=-g -O2 -Wall -I. -Wno-unused-function -Wno-gnu-statement-expression -Wno-c99-extensions -Wno-unused-variable
+CFLAGS=-g -O3 -Wall -I. -Wno-unused-function -Wno-gnu-statement-expression -Wno-c99-extensions -Wno-unused-variable
 
 MIN_IOS_VERSION=8.0
 

--- a/runtime/ejs-json.c
+++ b/runtime/ejs-json.c
@@ -258,7 +258,15 @@ JO(StringifyState *state, ejsval value)
     /* 4. Let indent be the concatenation of indent and gap. */
     state->indent = _ejs_string_concat (state->indent, state->gap);
 
-    ejsval K;
+    // XXX(toshok): we need this volatile because in the else case
+    // below(6), K is allocated, but then we never use the actual
+    // value of K again - we only access it via interior pointers.  so
+    // if the allocation of partial (7) happens to cause a GC (which
+    // happens during stage2 build), we free K and the loop at (8)
+    // crashes.  we need to switch to C++ to have some sort of stack
+    // rooting smart pointer-esque class.  There are probably lots of
+    // dragons of this sort around the code.
+    volatile ejsval K;
 
     /* 5. If PropertyList is not undefined, then */
     if (!EJSVAL_IS_UNDEFINED(state->PropertyList)) {


### PR DESCRIPTION
commit 0273dbe is the crux of the change.  It looks like since K wasn't accessed again as an ejsval after the allocation, llvm optimized it away -- accesses to it went through the EJS_ARRAY macros, which at most would have required the pointer portion of it.   The problem only seemed to happen on -O2, which makes sense.

This is just a quick fix to get stage2 compiling again.  we'll need a better solution.