### PR TITLE
Iterator closing1

### DIFF
--- a/runtime/ejs-array.c
+++ b/runtime/ejs-array.c
@@ -2213,8 +2213,8 @@ static EJS_NATIVE_FUNC(_ejs_Array_from) {
     ejsval thisArg = _ejs_undefined;
 
     if (argc > 0) items = args[0];
-    if (argc > 1) items = args[1];
-    if (argc > 2) items = args[2];
+    if (argc > 1) mapfn = args[1];
+    if (argc > 2) thisArg = args[2];
 
     // 1. Let C be the this value.
     ejsval C = *_this;

--- a/runtime/ejs-ops.c
+++ b/runtime/ejs-ops.c
@@ -1507,6 +1507,38 @@ IteratorValue_internal(ejsval* value, ejsval iterResult)
     return _ejs_invoke_func_catch(value, call_iterator_value, &iterResult);
 }
 
+// ES2015, June 2015
+// 7.4.6 IteratorClose ( iterator, completion )
+ejsval
+IteratorClose (ejsval iterator, ejsval completion, EJSBool completionIsThrow ) {
+    // 1. Assert: Type(iterator) is Object.
+    // 2. Assert: completion is a Completion Record.
+    // 3. Let return be GetMethod(iterator, "return").
+    // 4. ReturnIfAbrupt(return).
+    ejsval _return = GetMethod(iterator, _ejs_atom_return);
+
+    // 5. If return is undefined, return Completion(completion).
+    if (EJSVAL_IS_UNDEFINED(_return)) {
+        if (completionIsThrow) _ejs_throw(completion);
+        return completion;
+    }
+
+    // 6. Let innerResult be Call(return, iterator, « »).
+    // XXX _ejs_invoke_closure won't call proxy methods
+    ejsval innerResult = _ejs_invoke_closure(_return, &iterator, 0, NULL, _ejs_undefined);
+
+    // 7. If completion.[[type]] is throw, return Completion(completion).
+    if (completionIsThrow) _ejs_throw(completion);
+
+    // 8. If innerResult.[[type]] is throw, return Completion(innerResult).
+
+    // 9. If Type(innerResult.[[value]]) is not Object, throw a TypeError exception.
+    if (!EJSVAL_IS_OBJECT(innerResult)) _ejs_throw_nativeerror_utf8(EJS_TYPE_ERROR, "1");
+
+    // 10. Return Completion(completion).
+    if (completionIsThrow) _ejs_throw(completion);
+    return completion;
+}
 
 /* 7.4.6 IteratorStep ( iterator ) */
 ejsval

--- a/runtime/ejs-ops.h
+++ b/runtime/ejs-ops.h
@@ -96,6 +96,7 @@ ejsval GetIterator (ejsval obj, ejsval method);
 ejsval IteratorNext (ejsval iterator, ejsval value);
 ejsval IteratorComplete (ejsval iterResult);
 ejsval IteratorValue (ejsval iterResult);
+ejsval IteratorClose (ejsval iterator, ejsval completion, EJSBool completionIsThrow);
 ejsval IteratorStep (ejsval iterator);
 ejsval _ejs_create_iter_result (ejsval value, ejsval done);
 

--- a/runtime/ejs-set.c
+++ b/runtime/ejs-set.c
@@ -370,14 +370,15 @@ static EJS_NATIVE_FUNC(_ejs_Set_impl) {
         ejsval nextValue = IteratorValue (next);
 
         // f. Let status be Call(adder, set, «nextValue.[[value]]»).
-        _ejs_invoke_closure (adder, &set, 1, &nextValue, _ejs_undefined);
+        // XXX _ejs_invoke_closure won't call proxy methods
+        ejsval rv;
+
+        EJSBool status = _ejs_invoke_closure_catch (&rv, adder, &set, 1, &nextValue, _ejs_undefined);
 
         // g. If status is an abrupt completion, return IteratorClose(iter, status).
-
-        // XXX we need to use invoke_closure_catch here, and call IteratorClose
+        if (!status)
+            return IteratorClose(iter, rv, EJS_TRUE);
     }
-
-    EJS_NOT_REACHED();
 }
 
 static EJS_NATIVE_FUNC(_ejs_Set_get_species) {

--- a/runtime/ejs-weakmap.c
+++ b/runtime/ejs-weakmap.c
@@ -252,11 +252,12 @@ static EJS_NATIVE_FUNC(_ejs_WeakMap_impl) {
         ejsval nextItem = IteratorValue (next);
 
         // f. If Type(nextItem) is not Object,
-        // i. Let error be Completion{[[type]]: throw, [[value]]: a newly created TypeError object, [[target]]:empty}.
-        // ii. Return IteratorClose(iter, error).
         if (!EJSVAL_IS_OBJECT(nextItem)) {
-            // XXX we need to call IteratorClose here
-            _ejs_throw_nativeerror_utf8 (EJS_TYPE_ERROR, "non-object in iterable for WeakMap constructor");
+            // i. Let error be Completion{[[type]]: throw, [[value]]: a newly created TypeError object, [[target]]:empty}.
+            ejsval error = _ejs_nativeerror_new_utf8(EJS_TYPE_ERROR, "non-object in iterable for Map constructor");
+
+            // ii. Return IteratorClose(iter, error).
+            return IteratorClose(iter, error, EJS_TRUE);
         }
 
         // g. Let k be Get(nextItem, "0").
@@ -268,14 +269,17 @@ static EJS_NATIVE_FUNC(_ejs_WeakMap_impl) {
         ejsval v = Get(nextItem, _ejs_atom_1);  // XXX call IteratorClose here on exception
 
         // k. Let status be Call(adder, map, «k.[[value]], v.[[value]]»).
+        // XXX _ejs_invoke_closure won't call proxy methods
+        ejsval rv;
+
         ejsval adder_args[2];
         adder_args[0] = k;
         adder_args[1] = v;
-        _ejs_invoke_closure (adder, &map, 2, adder_args, _ejs_undefined);
+        EJSBool status = _ejs_invoke_closure_catch (&rv, adder, &map, 2, adder_args, _ejs_undefined);
 
         // l. If status is an abrupt completion, return IteratorClose(iter, status).
-
-        // XXX we need to use invoke_closure_catch here, and call IteratorClose
+        if (!status)
+            return IteratorClose(iter, rv, EJS_TRUE);
     }
 
     EJS_NOT_REACHED();

--- a/runtime/ejs-weakset.c
+++ b/runtime/ejs-weakset.c
@@ -214,14 +214,15 @@ static EJS_NATIVE_FUNC(_ejs_WeakSet_impl) {
         ejsval nextValue = IteratorValue (next);
 
         // f. Let status be Call(adder, set, «nextValue »).
-        _ejs_invoke_closure (adder, &set, 1, &nextValue, _ejs_undefined);
+        // XXX _ejs_invoke_closure won't call proxy methods
+        ejsval rv;
+
+        EJSBool status = _ejs_invoke_closure_catch (&rv, adder, &set, 1, &nextValue, _ejs_undefined);
 
         // g. If status is an abrupt completion, return IteratorClose(iter, status).
-
-        // XXX we need to use invoke_closure_catch here, and call IteratorClose
+        if (!status)
+            return IteratorClose(iter, rv, EJS_TRUE);
     }
-
-    EJS_NOT_REACHED();
 }
 
 ejsval _ejs_WeakSet EJSVAL_ALIGNMENT;


### PR DESCRIPTION
closing of iterators is something that went into es2015 after we really stopped tracking their work.  This adds proper behavior for the container (Map/Set/Weak*) ctors, as well as Array.from.  There is a bunch of other places that need similar treatment (`for...of`, destructuring, etc.) but those will be in a different PR.