### PR TITLE
add a Writer class that prints over the previous line if possible.

### DIFF
--- a/ejs-es6.js
+++ b/ejs-es6.js
@@ -14,7 +14,7 @@ import Set               from './lib/set-es6';
 import { compile }       from './lib/compiler';
 import { dumpModules, getAllModules, gatherAllModules } from './lib/passes/gather-imports';
 
-import { bold, reset, genFreshFileName } from './lib/echo-util';
+import { bold, reset, genFreshFileName, Writer } from './lib/echo-util';
 
 import { LLVM_SUFFIX as DEFAULT_LLVM_SUFFIX, RUNLOOP_IMPL as DEFAULT_RUNLOOP_IMPL } from './lib/host-config';
 
@@ -114,11 +114,12 @@ let options = {
     target_platform: host_platform,
     native_module_dirs: [],
     extra_clang_args: "",
-    ios_sdk: "9.1",
+    ios_sdk: "9.2",
     ios_min: "8.0",
     target_pointer_size: 64,
     import_variables: [],
-    srcdir: false
+    srcdir: false,
+    stdout_writer: new Writer(process.stdout)
 };
 
 function add_native_module_dir (dir) {
@@ -341,8 +342,7 @@ if (!file_args || file_args.length === 0) {
 }
 
 if (!options.quiet) {
-    console.log(`running on ${host_platform}-${host_arch}`);
-    console.log(`generating code for ${options.target_platform}-${options.target_arch}`);
+    console.log(`host: ${host_platform}-${host_arch}, target: ${options.target_platform}-${options.target_arch}`);
 }
 
 debug.setLevel(options.debug_level);
@@ -468,7 +468,7 @@ function compileFile(filename, parse_tree, modules, compileCallback) {
 
     if (!options.quiet) {
         let suffix = options.debug_level > 0 ? ` -> ${base_filename}` : '';
-        console.warn (`${bold()}COMPILE${reset()} ${filename}${suffix}`);
+        options.stdout_writer.write(`${bold()}COMPILE${reset()} ${filename}${suffix}`);
     }
 
     let compiled_module;
@@ -644,7 +644,7 @@ function do_final_link(main_file, modules) {
 
     clang_args = clang_args.concat(target_libraries(options.target_platform, options.target_arch));
 
-    if (!options.quiet) console.warn(`${bold()}LINK${reset()} ${output_filename}`);
+    if (!options.quiet) options.stdout_writer.write(`${bold()}LINK${reset()} ${output_filename}`);
     
     debug.log (1, `executing '${target_linker} ${clang_args.join(' ')}'`);
 

--- a/ejs-es6.js
+++ b/ejs-es6.js
@@ -463,12 +463,12 @@ let llvm_commands = {};
 for (let x of ["opt", "llc", "llvm-as"])
     llvm_commands[x]=`${x}${process.env.LLVM_SUFFIX || DEFAULT_LLVM_SUFFIX}`;
 
-function compileFile(filename, parse_tree, modules, compileCallback) {
+function compileFile(filename, parse_tree, modules, files_count, cur_file, compileCallback) {
     let base_filename = genFreshFileName(path.basename(filename));
 
     if (!options.quiet) {
         let suffix = options.debug_level > 0 ? ` -> ${base_filename}` : '';
-        options.stdout_writer.write(`${bold()}COMPILE${reset()} ${filename}${suffix}`);
+        options.stdout_writer.write(`[${cur_file}/${files_count}] ${bold()}COMPILE${reset()} ${filename}${suffix}`);
     }
 
     let compiled_module;
@@ -689,12 +689,13 @@ let allModules = getAllModules();
 //
 // reverse the list so the main program is the first thing we compile
 files.reverse();
+let files_count = files.length;
 let compileNextFile = () => {
         if (files.length === 0) {
             do_final_link(main_file, allModules);
             return;
         }
     let f = files.pop();
-    compileFile(f.file_name, f.file_ast, allModules, compileNextFile);
+    compileFile(f.file_name, f.file_ast, allModules, files_count, files_count - files.length, compileNextFile);
 }
 compileNextFile();

--- a/lib/echo-util.js
+++ b/lib/echo-util.js
@@ -118,3 +118,36 @@ export function intrinsic (id, args, loc) {
 export function sanitize_with_regexp (filename) {
     return filename.replace(/[.,-\/\\]/g, "_"); // this is insanely inadequate
 }
+
+export class Writer {
+    constructor(stream) {
+        this.stream = stream;
+        this.have_blank_line = true;
+    }
+
+    write(msg, want_newline = false) {
+        if (want_newline) {
+            if (!this.have_blank_line) {
+                this.stream.write('\n');
+            }
+        }
+        let out_msg = String(msg);
+        if (this.stream.isTTY && this.stream.columns > 0) {
+            let cols = this.stream.columns;
+            if (out_msg.length >= cols) {
+                // we should be awesome here and elide something from
+                // the middle of the line
+                out_msg = out_msg.substr(0, cols);
+            }
+            else {
+                out_msg = out_msg + ' '.repeat(cols - out_msg.length);
+            }
+            this.stream.write('\r');
+            this.stream.write(out_msg);
+            this.have_blank_line = false;
+        }
+        else {
+            this.stream.write(out_msg + '\n');
+        }
+    }
+}

--- a/lib/passes/gather-imports.js
+++ b/lib/passes/gather-imports.js
@@ -194,7 +194,7 @@ function gatherImports (filename, path, top_path, tree, import_vars) {
 function parseFile(filename, content, options) {
     try {
         if (!options.quiet)
-            console.log(`PARSE ${filename}`);
+            options.stdout_writer.write(`PARSE ${filename}`);
         return esprima.parse(content, { loc: true, raw: true, tolerant: true });
     }
     catch (e) {

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -31,6 +31,7 @@ C_SOURCES= \
 	ejs-regexp.c \
 	ejs-require.c \
 	ejs-set.c \
+	ejs-stream.c \
 	ejs-string.c \
 	ejs-symbol.c \
 	ejs-timers.c \

--- a/runtime/ejs-atoms.h
+++ b/runtime/ejs-atoms.h
@@ -110,6 +110,12 @@ EJS_ATOM(getRest)
 
 EJS_ATOM(argv)
 EJS_ATOM(process)
+EJS_ATOM(stdout)
+EJS_ATOM(stderr)
+EJS_ATOM(write)
+EJS_ATOM(end)
+EJS_ATOM(isTTY)
+EJS_ATOM(columns)
 
 // Object method/property names
 EJS_ATOM(assign)

--- a/runtime/ejs-init.c
+++ b/runtime/ejs-init.c
@@ -25,6 +25,7 @@
 #include "ejs-promise.h"
 #include "ejs-regexp.h"
 #include "ejs-require.h"
+#include "ejs-stream.h"
 #include "ejs-string.h"
 #include "ejs-symbol.h"
 #include "ejs-timers.h"
@@ -227,6 +228,7 @@ _ejs_init(int argc, char** argv)
     // function.  this should really be a separate opt-in .a/.so.
     _ejs_require_init(_ejs_global);
     _ejs_console_init(_ejs_global);
+    _ejs_stream_init(_ejs_global);
     _ejs_process_init(_ejs_global, argc, argv);
 
 #if IOS || OSX

--- a/runtime/ejs-process.c
+++ b/runtime/ejs-process.c
@@ -6,6 +6,7 @@
 #include "ejs-array.h"
 #include "ejs-gc.h"
 #include "ejs-function.h"
+#include "ejs-stream.h"
 #include "ejs-string.h"
 #include "ejs-error.h"
 #include "ejs-ops.h"
@@ -83,6 +84,9 @@ _ejs_process_init(ejsval global, uint32_t argc, char **argv)
 
     for (int i = 0; i < argc; i ++)
         _ejs_object_setprop (_argv, NUMBER_TO_EJSVAL(i), _ejs_string_new_utf8(argv[i]));
+
+    _ejs_object_setprop (_ejs_Process, _ejs_atom_stdout, _ejs_stream_wrapSysOutput(1));
+    _ejs_object_setprop (_ejs_Process, _ejs_atom_stderr, _ejs_stream_wrapSysOutput(2));
 
 #define OBJ_PROP(x) EJS_INSTALL_ATOM_GETTER(_ejs_Process, x, _ejs_Process_get_##x)
 #define OBJ_METHOD(x) EJS_INSTALL_ATOM_FUNCTION(_ejs_Process, x, _ejs_Process_##x)

--- a/runtime/ejs-stream.c
+++ b/runtime/ejs-stream.c
@@ -1,0 +1,103 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * vim: set ts=4 sw=4 et tw=99 ft=cpp:
+ */
+
+#include <unistd.h>
+#include <termios.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+
+#include "ejs.h"
+#include "ejs-error.h"
+#include "ejs-function.h"
+#include "ejs-ops.h"
+#include "ejs-string.h"
+#include "ejs-symbol.h"
+#include "ejs-value.h"
+
+static ejsval _ejs_internal_fd_sym EJSVAL_ALIGNMENT; 
+
+static EJS_NATIVE_FUNC(_ejs_stream_write) {
+    ejsval to_write = ToString(args[0]);
+    ejsval internal_fd = _ejs_object_getprop (*_this, _ejs_internal_fd_sym);
+    int fd = ToInteger(internal_fd);
+
+    int remaining = EJSVAL_TO_STRLEN(to_write);
+    int offset = 0;
+    char *buf = ucs2_to_utf8(EJSVAL_TO_FLAT_STRING(to_write));
+    
+    do {
+        int num_written = write (fd, buf + offset, remaining);
+        if (num_written == -1) {
+            if (errno == EINTR)
+                continue;
+            perror ("write");
+            free (buf);
+            return _ejs_false;
+        }
+        remaining -= num_written;
+        offset += num_written;
+    } while (remaining > 0);
+
+    free (buf);
+    return _ejs_true;
+}
+
+static EJS_NATIVE_FUNC(_ejs_stream_end) {
+    ejsval internal_fd = _ejs_object_getprop (*_this, _ejs_internal_fd_sym);
+    close (ToInteger(internal_fd));
+    return _ejs_undefined;
+}
+
+static EJS_NATIVE_FUNC(_ejs_stream_endThrow) {
+    _ejs_throw_nativeerror_utf8 (EJS_ERROR, "this stream cannot be closed");
+    EJS_NOT_REACHED();
+}
+
+ejsval
+_ejs_stream_wrapFd (int fd, EJSBool throwOnEnd)
+{
+    ejsval stream = _ejs_object_create(_ejs_null);
+
+    EJS_INSTALL_ATOM_FUNCTION(stream, write, _ejs_stream_write);
+    if (throwOnEnd) {
+        EJS_INSTALL_ATOM_FUNCTION(stream, end, _ejs_stream_endThrow);
+    }
+    else {
+        EJS_INSTALL_ATOM_FUNCTION(stream, end, _ejs_stream_end);
+    }
+
+    _ejs_object_setprop (stream, _ejs_internal_fd_sym, NUMBER_TO_EJSVAL(fd));
+
+    return stream;
+}
+
+static EJS_NATIVE_FUNC(_ejs_stream_getColumns) {
+    ejsval internal_fd = _ejs_object_getprop (*_this, _ejs_internal_fd_sym);
+    int fd = ToInteger(internal_fd);
+
+    struct winsize size;
+    if ((ioctl(fd, TIOCGWINSZ, &size) == 0) && size.ws_col) {
+        return NUMBER_TO_EJSVAL(size.ws_col);
+    }
+    return _ejs_undefined;
+}
+
+
+ejsval
+_ejs_stream_wrapSysOutput(int fd) {
+    ejsval stream = _ejs_stream_wrapFd(fd, EJS_TRUE);
+    if (isatty(fd)) {
+        _ejs_object_setprop (stream, _ejs_atom_isTTY, _ejs_true);
+        EJS_INSTALL_ATOM_GETTER(stream, columns, _ejs_stream_getColumns);
+    }
+    return stream;
+}
+
+void
+_ejs_stream_init(ejsval global)
+{
+    ejsval internal_fd_descr = _ejs_string_new_utf8("%internal_fd");
+    _ejs_gc_add_root (&_ejs_internal_fd_sym);
+    _ejs_internal_fd_sym = _ejs_symbol_new(internal_fd_descr);
+}

--- a/runtime/ejs-stream.h
+++ b/runtime/ejs-stream.h
@@ -1,0 +1,19 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * vim: set ts=4 sw=4 et tw=99 ft=cpp:
+ */
+
+#ifndef _ejs_stream_h_
+#define _ejs_stream_h_
+
+#include "ejs.h"
+#include "ejs-value.h"
+
+EJS_BEGIN_DECLS
+
+extern ejsval _ejs_stream_wrapFd (int fd, EJSBool throwOnEnd);
+extern ejsval _ejs_stream_wrapSysOutput(int fd);
+extern void _ejs_stream_init(ejsval global);
+
+EJS_END_DECLS
+
+#endif


### PR DESCRIPTION
this should clean up the compiler output by reusing the same line for
most output (if stdout is a tty.)